### PR TITLE
Make `newline` index search cross-platform

### DIFF
--- a/check.js
+++ b/check.js
@@ -47,7 +47,21 @@ async function parseTest(files) {
       while (true) {
         pos = source.indexOf(PREFIX, prev + 1)
         if (pos === -1) break
-        let newline = source.search(/\r?\n/, pos)
+        let newline = source.slice(pos).search(/\r?\n/)
+
+        /*
+          To start searching `newline` value from a particular index (`pos`),
+          the part before the index is removed and the search is performed.
+          If the search was successful, it is necessary to add `pos` value to
+          the `newline` one to imitate, that the search was performed on the
+          full string.
+          If the search wasn't successful (`newline` === -1), keep it as is for
+          further usage.
+        */
+        if (newline !== -1) {
+          newline += pos
+        }
+
         let pattern = source.slice(pos + PREFIX.length, newline)
         let { line, column } = lines.toPoint(pos)
         expects.push({ fileName, line: line + 1, column, pattern })

--- a/check.js
+++ b/check.js
@@ -47,7 +47,7 @@ async function parseTest(files) {
       while (true) {
         pos = source.indexOf(PREFIX, prev + 1)
         if (pos === -1) break
-        let newline = source.indexOf('\n', pos)
+        let newline = source.search(/\r?\n/, pos)
         let pattern = source.slice(pos + PREFIX.length, newline)
         let { line, column } = lines.toPoint(pos)
         expects.push({ fileName, line: line + 1, column, pattern })


### PR DESCRIPTION
Closes #19

What has been done:
* Changed `newline` index search using a regexp, which takes into account both `\n` and `\r\n` characters. Since a regexp is used instead of a string, `indexOf` has been changed to `search`.
  Inspired by: https://stackoverflow.com/questions/8125709/javascript-how-to-split-newline/45709854#45709854
* Checked the work locally using [yarn link](https://classic.yarnpkg.com/en/docs/cli/link/) feature.