### PR TITLE
fix: recognize tsconfig.compilerOptions.lib

### DIFF
--- a/test/fixtures/tsconfig/index.ts
+++ b/test/fixtures/tsconfig/index.ts
@@ -1,5 +1,9 @@
 function sealed (target: any) {
-  target.seal = 'SEAL'
+  target.seal = 'seal'
+}
+
+function all(p1: Promise<void>, p2: Promise<void>) {
+  return Promise.allSettled([p1, p2])
 }
 
 @sealed

--- a/test/fixtures/tsconfig/tsconfig.json
+++ b/test/fixtures/tsconfig/tsconfig.json
@@ -2,6 +2,9 @@
   "compilerOptions": {
     "target": "ES5",
     "experimentalDecorators": true,
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "lib": [
+      "ES2020.Promise"
+    ]
   }
 }


### PR DESCRIPTION
I encounter an issue while using `lib` in my project. Here is the config:

```json
{
  "compilerOptions": {
    "target": "es2020",
    "module": "esnext",
    "moduleResolution": "node",
    "esModuleInterop": true,
    "skipLibCheck": true,
    "allowJs": true,
    "strict": true,
    "noEmit": true,
    "lib": [
      "ES2020.Promise"
    ],
    "types": [
      "node",
      "jest"
    ]
  },
  "exclude": [
    "**/errors.ts"
  ]
}
```

Works fine with `tsc` but doesn't work with `check-dts`.

It turned out that `lib` contents must be converted to be used with `ts.createProgram`. So, I refactored the code to use `ts.convertCompilerOptionsFromJson`.

However, that didn't solved the original issue: for some reason, ts doesn't pick up lib files. To fix this, I added a hack to push the libs to the list of files. My problem was solved.
