### PR TITLE
Add "CLI options" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $ npx check-dts
   Got: Expected 3 arguments, but got 2.
 ```
 
-## CLI options
+## CLI Options
 
 ```bash
 [FILES]    A list of files/globs, passed as 2nd, 3d, etc. argument. Default value: **/*.{js,ts,jsx,tsx}

--- a/README.md
+++ b/README.md
@@ -109,3 +109,18 @@ $ npx check-dts
   Expected: Expected 0 arguments, but got 1
   Got: Expected 3 arguments, but got 2.
 ```
+
+## CLI options
+
+```bash
+[FILES]    A list of files/globs, passed as 2nd, 3d, etc. argument. Default value: **/*.{js,ts,jsx,tsx}
+--version  Show version
+--help     Show list of CLI options
+```
+
+Examples of `[FILES]` option usage:
+
+```bash
+$ npx check-dts **/*.tsx?
+$ npx check-dts **/*.ts !**/index.ts
+```

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
       "JS",
       "CI",
       "js",
-      "ES"
+      "ES",
+      "CLI"
     ]
   },
   "sharec": {


### PR DESCRIPTION
What has been done:
* Add "CLI options" section to the docs
* Add CLI options usage examples
* Add "CLI" to "yaspeller" dictionary