### PR TITLE
Report errors not associated with a file

### DIFF
--- a/check.js
+++ b/check.js
@@ -20,6 +20,7 @@ const ROOT = dirname(fileURLToPath(import.meta.url))
 const TS_DIR = dirname(require.resolve('typescript'))
 const WORKER = join(ROOT, 'worker.js')
 const PREFIX = '// THROWS '
+const IS_TEST = process.env.NODE_ENV === 'test';
 
 function checkFiles(files, compilerOptions) {
   return new Promise((resolve, reject) => {
@@ -111,7 +112,12 @@ export async function check(
 
     // istanbul ignore next
     if (!error.file) {
-      push(error)
+      let message = error.messageText.messageText;
+      // To support snapshot tests, remove absolute paths that would vary between machines.
+      if (IS_TEST) {
+        message = message.replaceAll(process.cwd(), '$CWD')
+      }
+      push(error, message);
       continue
     }
 

--- a/check.js
+++ b/check.js
@@ -115,7 +115,7 @@ export async function check(
       let message = error.messageText.messageText;
       // To support snapshot tests, remove absolute paths that would vary between machines.
       if (IS_TEST) {
-        message = message.replaceAll(process.cwd(), '$CWD')
+        message = message.replaceAll(process.cwd(), '.')
       }
       push(error, message);
       continue

--- a/check.js
+++ b/check.js
@@ -20,7 +20,6 @@ const ROOT = dirname(fileURLToPath(import.meta.url))
 const TS_DIR = dirname(require.resolve('typescript'))
 const WORKER = join(ROOT, 'worker.js')
 const PREFIX = '// THROWS '
-const IS_TEST = process.env.NODE_ENV === 'test';
 
 function checkFiles(files, compilerOptions) {
   return new Promise((resolve, reject) => {
@@ -112,11 +111,8 @@ export async function check(
 
     // istanbul ignore next
     if (!error.file) {
-      let message = error.messageText.messageText;
       // To support snapshot tests, remove absolute paths that would vary between machines.
-      if (IS_TEST) {
-        message = message.replaceAll(process.cwd(), '.')
-      }
+      let message = error.messageText.messageText.replaceAll(process.cwd(), '.')
       push(error, message);
       continue
     }

--- a/test/__snapshots__/check.test.js.snap
+++ b/test/__snapshots__/check.test.js.snap
@@ -102,7 +102,7 @@ exports[`shows errors not associated with a file 1`] = `
 "[33m-[39m Check types
 [31m✖[39m Check types
 
-File '$CWD/test/fixtures/tsconfig-with-file-not-included/tool.config.ts' is not under 'rootDir' '$CWD/test/fixtures/tsconfig-with-file-not-included/src'. 'rootDir' is expected to contain all source files.
+File './test/fixtures/tsconfig-with-file-not-included/tool.config.ts' is not under 'rootDir' './test/fixtures/tsconfig-with-file-not-included/src'. 'rootDir' is expected to contain all source files.
 
 "
 `;

--- a/test/__snapshots__/check.test.js.snap
+++ b/test/__snapshots__/check.test.js.snap
@@ -102,7 +102,7 @@ exports[`shows errors not associated with a file 1`] = `
 "[33m-[39m Check types
 [31m✖[39m Check types
 
-undefined
+File '$CWD/test/fixtures/tsconfig-with-file-not-included/tool.config.ts' is not under 'rootDir' '$CWD/test/fixtures/tsconfig-with-file-not-included/src'. 'rootDir' is expected to contain all source files.
 
 "
 `;

--- a/test/__snapshots__/check.test.js.snap
+++ b/test/__snapshots__/check.test.js.snap
@@ -98,6 +98,15 @@ exports[`loads custom tsconfig.json with extends property 1`] = `
 "
 `;
 
+exports[`shows errors not associated with a file 1`] = `
+"[33m-[39m Check types
+[31m✖[39m Check types
+
+undefined
+
+"
+`;
+
 exports[`supports simple cases 1`] = `
 "[33m-[39m Check types
 [32m✔[39m Check types

--- a/test/check.test.js
+++ b/test/check.test.js
@@ -66,6 +66,10 @@ it('accepts files', async () => {
   expect(await good('negative', 'b.*')).toMatchSnapshot()
 })
 
+it('shows errors not associated with a file', async () => {
+  expect(await bad('tsconfig-with-file-not-included')).toMatchSnapshot()
+})
+
 it('warns about empty project', async () => {
   let error
   try {

--- a/test/fixtures/tsconfig-with-file-not-included/src/add.ts
+++ b/test/fixtures/tsconfig-with-file-not-included/src/add.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number) {
+  return a + b;
+}

--- a/test/fixtures/tsconfig-with-file-not-included/src/types.ts
+++ b/test/fixtures/tsconfig-with-file-not-included/src/types.ts
@@ -1,0 +1,3 @@
+import { add } from './add'
+
+add(1, 2)

--- a/test/fixtures/tsconfig-with-file-not-included/tool.config.ts
+++ b/test/fixtures/tsconfig-with-file-not-included/tool.config.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/test/fixtures/tsconfig-with-file-not-included/tsconfig.json
+++ b/test/fixtures/tsconfig-with-file-not-included/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "ESNext",
+    "lib": [
+      "ES2020.Promise"
+    ],
+    "rootDir": "./src",
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
I have some projects that use a TSConfig file with `rootDir` and `includes` referring to the project source files, but that also have a TypeScript configuration file for some tool (Vite, Jest, etc) outside of that `rootDir`.

Running `check-dts` on such a project fails with an uninformative error message:
```
$ check-dts
✖ Check types

undefined
```

This can be reproduced using the`tsconfig-with-file-not-included` fixture added in the first commit of this PR (https://github.com/ai/check-dts/commit/ea3c0013a1648f421dc29fa8c6dd75fc9f0223db).
```
$ cd test/fixtures/tsconfig-with-file-not-included
$ node ../../../bin.js
✖ Check types

undefined
```

In this case, it turns out that the `errors` list...
https://github.com/ai/check-dts/blob/7020f61159798fbe19d2a1e38aadd75ab0c7ccc5/check.js#L98

contains an object like:
```
[
  {
    messageText: {
      messageText: "File '/path/to/check-dts/test/fixtures/tsconfig-with-file-not-included/tool.config.ts' is not under 'rootDir' '/path/to/check-dts/test/fixtures/tsconfig-with-file-not-included/src'. 'rootDir' is expected to contain all source files.",
      category: 1,
      code: 6059,
      next: [Array]
    },
    fileName: undefined,
    start: undefined,
    code: 6059
  }
]
```

Because that error object has no `file` property, it is added to the `bad` object with an undefined error message (`push` is called without a second argument).
https://github.com/ai/check-dts/blob/7020f61159798fbe19d2a1e38aadd75ab0c7ccc5/check.js#L113-L116

This results in `bad` containing:
```
{ '[object Object]': [ undefined ] }
```



To address this, this PR adds an error message / second argument to `push` using the error's `messageText` property.

Afterwards, running `check-dts` on the fixture produces a useful error message:
```
$ cd test/fixtures/tsconfig-with-file-not-included
$ node ../../../bin.js
✖ Check types

File '/path/to/check-dts/test/fixtures/tsconfig-with-file-not-included/tool.config.ts' is not under 'rootDir' '/path/to/check-dts/test/fixtures/tsconfig-with-file-not-included/src'. 'rootDir' is expected to contain all source files.
```

Snapshot testing for this is slightly complicated since the error produced by this test fixture includes an absolute path, which would vary between machines. To work around this, in tests, those absolute paths are normalized by replacing the path to the current working directory with a placeholder.

This may resolve #38.