### PR TITLE
Added example as FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ To check the return value of a library, simply set the type to the variable in y
 const test: string = await myFunction();
 ```
 
-If the variable only returns a string a never a number, then this will fail:
+If the function only returns a string a never a number, then this will fail:
 
 ```ts
 // FAILS

--- a/README.md
+++ b/README.md
@@ -166,3 +166,18 @@ You can skip the whole `node_modules` by adding to `tsconfig.json`:
   }
 }
 ```
+
+### Checking the type of the return value
+
+To check the return value of a library, simply set the type to the variable in your `index.d.ts`:
+
+```ts
+const test: string = await myFunction();
+```
+
+If the variable only returns a string a never a number, then this will fail:
+
+```ts
+// FAILS
+const test: number = await myFunction();
+```


### PR DESCRIPTION
[Based on this issue](https://github.com/ai/check-dts/issues/40), added an example of how to check the return type:

(added content follows)

***

### Checking the type of the return value

To check the return value of a library, simply set the type to the variable in your `index.d.ts`:

```ts
const test: string = await myFunction();
```

If the function only returns a string a never a number, then this will fail:

```ts
// FAILS
const test: number = await myFunction();
```